### PR TITLE
support for explicit plus in mantissa

### DIFF
--- a/lib/Lingua/EN/Numbers.pm
+++ b/lib/Lingua/EN/Numbers.pm
@@ -229,7 +229,7 @@ sub _e2en {
         )
        )
       [eE]
-      (-?\d+)   # mantissa, has to be an integer
+      ([-+]?\d+)   # mantissa, has to be an integer
       $
     >x
   ) {

--- a/t/30_v1_tests.t
+++ b/t/30_v1_tests.t
@@ -1,7 +1,7 @@
 
 use strict;
 use Test;
-BEGIN { plan tests => 58 }
+BEGIN { plan tests => 60 }
 
 use Lingua::EN::Numbers qw(num2en num2en_ordinal);
 print "# Using Lingua::EN::Numbers v$Lingua::EN::Numbers::VERSION\n";
@@ -58,6 +58,8 @@ ok N '-14.000', 'negative fourteen point zero zero zero';
 
 # and maybe even:
 ok N '-1.53e34',  'negative one point five three times ten to the thirty-fourth';
+ok N  -1.53e34,   'negative one point five three times ten to the thirty-fourth';
+ok N '-1.53e+34', 'negative one point five three times ten to the thirty-fourth';
 ok N '-1.53e-34', 'negative one point five three times ten to the negative thirty-fourth';
 ok N '+19e009', 'positive nineteen times ten to the ninth';
 


### PR DESCRIPTION
The module only supports numbers like "1e21", but not 1e21 (in numeric form), because it's converted by perl to 1e+21:
```
$ perl -E 'say 1_000_000_000_000_000_000_000'
1e+21
```